### PR TITLE
Update to Ultimaille 2.0.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ultimaille"]
 	path = ultimaille
-	url = https://github.com/ssloy/ultimaille
+	url = https://github.com/ultimaille/ultimaille
 [submodule "amgcl"]
 	path = amgcl
 	url = https://github.com/ddemidov/amgcl

--- a/main.cpp
+++ b/main.cpp
@@ -23,7 +23,7 @@ void soft_deformation(Triangles& m, FacetAttribute<int>& flag) {
 	nlBegin(NL_MATRIX);
 	FOR(f, m.nfacets()) {
 		int dim = flag[f] / 2;
-		vec3 n = m.util.normal(f);
+		vec3 n = Triangles::Facet(m,f).geom<Triangle3>().normal();
 		FOR(d, 3) {
 			FOR(fv, 3) {
 				nlRowScaling(std::sqrt(n.norm()));
@@ -76,7 +76,7 @@ void hard_deformation(Triangles& m, FacetAttribute<int>& flag) {
 	nlBegin(NL_MATRIX);
 	FOR(f, m.nfacets()) {
 		int dim = flag[f] / 2;
-		double parea = std::sqrt(m.util.unsigned_area(f));
+		double parea = std::sqrt(Triangles::Facet(m,f).geom<Triangle3>().unsigned_area());
 		FOR(d, 3) {
 			if (dim == d) continue;
 			FOR(fv, 3) {
@@ -108,10 +108,10 @@ void hard_deformation(Triangles& m, FacetAttribute<int>& flag) {
 }
 
 
-void naive_flag_mesh(const Triangles& m, FacetAttribute<int>& flags) {
+void naive_flag_mesh(Triangles& m, FacetAttribute<int>& flags) {
 	const std::array<vec3, 6> AXES = { {{1.,0.,0.},{-1.,0.,0.},{0.,1.,0.},{0.,-1.,0.},{0.,0.,1.},{0.,0.,-1.}} };
 	FOR(f, m.nfacets()) {
-		vec3 n = m.util.normal(f);
+		vec3 n = Triangles::Facet(m,f).geom<Triangle3>().normal();
 		flags[f] = 0;
 		double best = AXES[0] * n;
 		FOR(i, 5) if (n * AXES[i + 1] > best) {


### PR DESCRIPTION
Hi François,

Here are some modif I did to have a newer Ultimaille.
- reference the new URL (`ultimaille/ultimaille` instead of `ssloy/ultimaille`)
- `git checkout` to the [v2.0.0](https://github.com/ultimaille/ultimaille/releases/tag/v2.0.0)
- tweak `main.cpp` for the new API (no more `m.utils` but primitives). I didn't update and didn't try to compile `main_w_amgcl.cpp`, but IntelliSense seems happy.

Tested with the provided `boundary.obj` and another mesh.

Note: `Triangles& m` argument of `naive_flag_mesh()` is not const anymore because of the [`Primitive` constructor](https://github.com/ultimaille/ultimaille/blob/v2.0.0/ultimaille/surface.h#L80). (To be) fixed, see [issue#83](https://github.com/ultimaille/ultimaille/issues/83) and [PR#87](https://github.com/ultimaille/ultimaille/issues/83), but I didn't manage to compile the `master` branch.